### PR TITLE
LIBITD-698. Removed the "About" link from the navigation bar.

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,20 +19,7 @@
         <div class="col-sm-12">
           <div id="header-navbar" class="navbar navbar-static-top" role="navigation">
             <div class="navbar-header">
-              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#user-util-collapse">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-              </button>
               <a class="navbar-brand" href="/">Reciprocal Borrowing</a>
-            </div>
-            <div class="collapse navbar-collapse" id="user-util-collapse">
-              <div class="navbar-right">
-                <ul class="nav navbar-nav">
-                  <li><a href="http://www.btaa.org/projects/library/reciprocal-borrowing/introduction">About</a></li>
-                </ul>
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Also removed the button that expands/collapses display of the link in
the navigation bar, as it would no longer display any items, and it
seemed unnecessary to have it show up when the browser window width
was narrow.

https://issues.umd.edu/browse/LIBITD-698