### PR TITLE
LIBITD-879. Add authorization check to attributes display page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,17 @@ For local development, this application can be used in conjunction with the Vagr
 
 The functionality of this application is extremely straightforward:
 
-1) The home page provides a list of organizations participating in reciprocal borrowing. After selecting a page, the application redirects the browser (via an entityID provided to the Shibboleth SP running on the server) to a Shibboleth IdP for the selected organization.
+1) The home page provides a list of organizations participating in reciprocal borrowing. On this page, the organization doing the lending is selected.
 
-2) The user authenticates via their organizational authentication process.
+2) After selecting the lending organization, a second page is shown with a list of organizations. The authenticating organization (the organization the borrowing patron is a member) is selected. After selecting the organication, the application redirects the browser (via an entityID provided to the Shibboleth SP running on the server) to a Shibboleth IdP for the selected organization.
 
-**Note:** This step takes place entirely outside of this application, so this application never has access to the user's credentials.
+2) The borrowing patron authenticates via their organizational authentication process.
 
-3) After successfully authenticating, the browser is redirected back to this application, which displays a "successful authentication" page.
+**Note:** This step takes place entirely outside of this application, so this application never has access to the patron's credentials.
+
+3) After successfully authenticating, the browser is redirected back to this application, which indicates whether the patron is eligible to borrow.
+
+**Note:** The local development environment (when used in conjunction with the "reciprocal-borrowing-vagrant" as the Shibboleth SP and IdP) *cannot* show that a user is eligible to borrow because the IdP is not configured to pass the "eduPersonScopedAffiliation" back to the application. Conversely, when running on the dev, stage, or production servers, there is no known way to show that a user in ineligible for borrow because the UMD server always seems pass back the expected property.
 
 ## Application Configuration
 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -81,3 +81,11 @@ section#authentication-message {
   text-align: center;
   font-size: 140%;
 }
+
+.lending-org-name {
+    font-weight: bold;
+}
+
+.disabled-link {
+    color: gray
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -89,3 +89,8 @@ section#authentication-message {
 .disabled-link {
     color: gray
 }
+
+.user-not-authorized strong {
+    font-weight: bold;
+    color: red;
+}

--- a/app/controllers/shibboleth_login_controller.rb
+++ b/app/controllers/shibboleth_login_controller.rb
@@ -4,6 +4,20 @@ class ShibbolethLoginController < ApplicationController
     @org_list = organizations.values.sort_by { |v| v['display_order'] }
   end
 
+  def authenticate
+    @lending_org_code = params['lending_org_code']
+    organizations = Rails.configuration.shibboleth_config['organizations']
+
+    if organizations.key?(@lending_org_code)
+      @org_list = organizations.values.sort_by { |v| v['display_order'] }
+      lending_org = organizations[@lending_org_code]
+      @lending_org_name = lending_org['name']
+    else
+      # Was not given a valid org_code, treat as 404 error
+      redirect_to not_found_url
+    end
+  end
+
   def initiator # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     org_code = params['org_code']
     organizations = Rails.configuration.shibboleth_config['organizations']

--- a/app/controllers/shibboleth_login_controller.rb
+++ b/app/controllers/shibboleth_login_controller.rb
@@ -38,7 +38,8 @@ class ShibbolethLoginController < ApplicationController
     end
   end
 
-  def callback # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def callback
     @lending_org_code = session[:lending_org_code]
     @auth_org_code = session[:auth_org_code]
 
@@ -53,8 +54,13 @@ class ShibbolethLoginController < ApplicationController
 
     @user_authorized = user_authorized?(@auth_org_code, @affiliation)
 
-    TransactionsLogger.info(@identifier)
+    transaction_entry = "#{@identifier}," \
+                        "lending_org_code=#{@lending_org_code || 'N/A'}," \
+                        "auth_org_code=#{@auth_org_code || 'N/A'}," \
+                        "authorized=#{@user_authorized}"
+    TransactionsLogger.info(transaction_entry)
   end
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def hosting
   end

--- a/app/controllers/shibboleth_login_controller.rb
+++ b/app/controllers/shibboleth_login_controller.rb
@@ -4,7 +4,7 @@ class ShibbolethLoginController < ApplicationController
     @org_list = organizations.values.sort_by { |v| v['display_order'] }
   end
 
-  def authenticate
+  def authenticate # rubocop:disable Metrics/AbcSize
     @lending_org_code = params['lending_org_code']
     organizations = Rails.configuration.shibboleth_config['organizations']
 
@@ -12,6 +12,7 @@ class ShibbolethLoginController < ApplicationController
       @org_list = organizations.values.sort_by { |v| v['display_order'] }
       lending_org = organizations[@lending_org_code]
       @lending_org_name = lending_org['name']
+      session[:lending_org_code] = @lending_org_code
     else
       # Was not given a valid org_code, treat as 404 error
       redirect_to not_found_url
@@ -27,6 +28,7 @@ class ShibbolethLoginController < ApplicationController
     if organizations.key?(org_code)
       org = organizations[org_code]
       idp_entity_id = org['idp_entity_id']
+      session[:auth_org_code] = org_code
       url_encoded_idp_entity_id = ERB::Util.url_encode(idp_entity_id)
       url_with_callback = "#{sp_login_url}?entityID=#{url_encoded_idp_entity_id}&target=#{callback_url}"
       redirect_to url_with_callback
@@ -36,7 +38,10 @@ class ShibbolethLoginController < ApplicationController
     end
   end
 
-  def callback # rubocop:disable Metrics/AbcSize
+  def callback # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    @lending_org_code = session[:lending_org_code]
+    @auth_org_code = session[:auth_org_code]
+
     @env = request.env
     @params = request.params
 
@@ -46,9 +51,22 @@ class ShibbolethLoginController < ApplicationController
     @principal_name = @env['eduPersonPrincipalName'] || 'N/A'
     @identifier = @env['eduPersonTargetedID'] || 'N/A'
 
+    @user_authorized = user_authorized?(@auth_org_code, @affiliation)
+
     TransactionsLogger.info(@identifier)
   end
 
   def hosting
   end
+
+  private
+
+    # Returns true is the user is authorized, false otherwise.
+    #
+    # auth_org_code: The code of the organizaton performing the authorization
+    # affiliation: the eduPersonScopedAffiliation parameter from Shibboleth
+    def user_authorized?(auth_org_code, affiliation)
+      expected_affliation = "member@#{auth_org_code}.edu"
+      affiliation.split(';').include?(expected_affliation)
+    end
 end

--- a/app/views/shibboleth_login/authenticate.html.erb
+++ b/app/views/shibboleth_login/authenticate.html.erb
@@ -1,0 +1,35 @@
+<% provide(:title, "Authenticate") %>
+
+<div role="main" id="main-container" class="container">
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="row">
+        <div id='project-text'>
+          <p>The lending institution will be recorded as <span class="lending-org-name"><%= @lending_org_name %></span>.
+          If this is not correct you can return to the <%= link_to 'Home Page', root_url %> to re-select.</p>
+
+          <p>To authenticate, please click on your home institution below
+          and log-in using your institution user ID and password. A
+          successful result will return your name, affiliation, and
+          personal identifier number.</p>
+        </div>
+
+        <ul id="organization_list">
+          <% @org_list.each do |org| %>
+            <% org_code = org['code'] %>
+            <% org_name = org['name'] %>
+
+            <%= content_tag(:li, class: "", id: org_code + "_entry") do %>
+              <% if org_code == @lending_org_code %>
+                <%# No link for organization that is doing the lending. %>
+                <span class="disabled-link"><%= org_name %></span>
+              <% else %>
+                <%= link_to org_name, initiator_path(org_code: org_code) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shibboleth_login/callback.html.erb
+++ b/app/views/shibboleth_login/callback.html.erb
@@ -26,11 +26,11 @@
         <section id="authentication-message">
           <% if @user_authorized %>
             <p class="user-authorized">
-              User is eligible for borrowing based on Affiliation of member@<%= @auth_org_code %>.edu
+              User is eligible for borrowing
             </p>
           <% else %>
             <p class="user-not-authorized">
-              User is <strong>NOT</strong> eligible for borrowing due to missing member@<%= @auth_org_code %>.edu in Affiliation
+              User is <strong>NOT</strong> eligible for borrowing – not recognized as member@<%= @auth_org_code %>.edu
             <p>
           <% end %>
           <p>

--- a/app/views/shibboleth_login/callback.html.erb
+++ b/app/views/shibboleth_login/callback.html.erb
@@ -22,15 +22,17 @@
             <td><%= @identifier %></td>
           </tr>
         </table>
-        
+
         <section id="authentication-message">
-          <p>
-            AUTHENTICATION SUCCESSFUL
-          </p>
-          <p>
-            Users eligible for borrowing will see “member@(institution).edu” in
-            the Affiliation category
-          <p>
+          <% if @user_authorized %>
+            <p class="user-authorized">
+              User is eligible for borrowing based on Affiliation of member@<%= @auth_org_code %>.edu
+            </p>
+          <% else %>
+            <p class="user-not-authorized">
+              User is <strong>NOT</strong> eligible for borrowing due to missing member@<%= @auth_org_code %>.edu in Affiliation
+            <p>
+          <% end %>
           <p>
             For security purposes please close your browser to exit the system
           <p>
@@ -47,7 +49,7 @@
 
               <ul>
                 <% @env.each do |key, value| %>
-                  <li><%= key %>: <%= value %></li> 
+                  <li><%= key %>: <%= value %></li>
                 <% end %>
               </ul>
 
@@ -55,7 +57,7 @@
 
               <ul>
                 <% @params.each do |key, value| %>
-                  <li><%= key %>: <%= value %></li> 
+                  <li><%= key %>: <%= value %></li>
                 <% end %>
               </ul>
             </div>

--- a/app/views/shibboleth_login/home.html.erb
+++ b/app/views/shibboleth_login/home.html.erb
@@ -15,18 +15,15 @@
           their current affiliation by authenticating through use of this
           BTAA Reciprocal Borrowing Application.</p>
 
-          <p>To authenticate, please click on your home institution below
-          and log-in using your institution user ID and password. A
-          successful result will return your name, affiliation, and
-          personal identifier number.</p>
+          <p>Please select the lending institution.</p>
         </div>
 
         <ul id="organization_list">
           <% @org_list.each do |org| %>
-            <% org_code = org['code'] %>
-            <% org_name = org['name'] %>
-            <li id="<%= org_code + "_entry" %>">
-            <a href="/initiate/<%= org_code %>"><%= org_name %></a>
+            <% lending_org_code = org['code'] %>
+            <% lending_org_name = org['name'] %>
+            <li id="<%= lending_org_code + "_entry" %>">
+            <a href="/authenticate/<%= lending_org_code %>"><%= lending_org_name %></a>
             </li>
           <% end %>
         </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   root 'shibboleth_login#home'
 
-  get 'initiate/:org_code' => 'shibboleth_login#initiator'
+  get 'authenticate/:lending_org_code' => 'shibboleth_login#authenticate', as: :authenticator
+  get 'initiate/:org_code' => 'shibboleth_login#initiator', as: :initiator
 
   get 'attributes' => 'shibboleth_login#callback'
 

--- a/config/shibboleth_config.yml
+++ b/config/shibboleth_config.yml
@@ -11,14 +11,15 @@ production:
   #
   # Each entry in the "organizations" map MUST adhere to the following form:
   #
-  #   <org_code>:       
+  #   <org_code>:
   #     code: <org_code>
   #     name: <human-readable name of the organization>
   #     idp_entity_id: <entityId for the organization's IDP>
   #     display_order: <number used to sort entries>
   #
   # The <org_code> must be unique, and the "code" field of the entry must
-  # match the <org_code> of the entry.
+  # match the <org_code> of the entry. This will typically be the taken from
+  # the idp_entity_id.
   #
   # The "idp_entity_id" should contain the entityID of the organization's IDP.
   # One source of this information is:
@@ -34,92 +35,92 @@ production:
   # YAML anchors (&id_<org_code>) are used to facilitate reuse the entries
   # in the "development" and "test" environments.
   organizations: &id_organizations
-    chicago: &id_chicago
-      code: 'chicago'
+    uchicago: &id_uchicago
+      code: 'uchicago'
       name: 'University of Chicago'
       idp_entity_id: 'urn:mace:incommon:uchicago.edu'
       display_order: 0
 
-    illinois: &id_illinois
-      code: 'illinois'
+    uiuc: &id_uiuc
+      code: 'uiuc'
       name: 'University of Illinois'
       idp_entity_id: 'urn:mace:incommon:uiuc.edu'
       display_order: 1
-      
-    indiana: &id_indiana
-      code: 'indiana'
+
+    iu: &id_iu
+      code: 'iu'
       name: 'Indiana University'
       idp_entity_id: 'urn:mace:incommon:iu.edu'
       display_order: 2
-    
-    iowa: &id_iowa
-      code: 'iowa'
+
+    uiowa: &id_uiowa
+      code: 'uiowa'
       name: 'University of Iowa'
       idp_entity_id: 'urn:mace:incommon:uiowa.edu'
       display_order: 3
-    
-    maryland: &id_maryland
-      code: 'maryland'
+
+    umd: &id_umd
+      code: 'umd'
       name: 'University of Maryland'
       idp_entity_id: 'urn:mace:incommon:umd.edu'
       display_order: 4
-    
-    university_of_michigan: &id_university_of_michigan
-      code: 'university_of_michigan'
+
+    umich: &id_umich
+      code: 'umich'
       name: 'University of Michigan'
       idp_entity_id: 'https://shibboleth.umich.edu/idp/shibboleth'
       display_order: 5
-    
-    michigan_state: &id_michigan_state
-      code: 'michigan_state'
+
+    msu: &id_msu
+      code: 'msu'
       name: 'Michigan State University'
       idp_entity_id: 'urn:mace:incommon:msu.edu'
       display_order: 6
-    
-    minnesota: &id_minnesota
-      code: 'minnesota'
+
+    umn: &id_umn
+      code: 'umn'
       name: 'University of Minnesota'
       idp_entity_id: 'urn:mace:incommon:umn.edu'
       display_order: 7
-    
-    nebraska: &id_nebraska
-      code: 'nebraska'
+
+    unl: &id_unl
+      code: 'unl'
       name: 'University of Nebraska-Lincoln'
       idp_entity_id: 'https://shib.unl.edu/idp/shibboleth'
       display_order: 8
-    
+
     northwestern: &id_northwestern
       code: 'northwestern'
       name: 'Northwestern University'
       idp_entity_id: 'urn:mace:incommon:northwestern.edu'
       display_order: 9
-    
-    ohio: &id_ohio
-      code: 'ohio'
+
+    osu: &id_osu
+      code: 'osu'
       name: 'Ohio State University'
       idp_entity_id: 'urn:mace:incommon:osu.edu'
       display_order: 10
-    
-    pennsylvania: &id_pennsylvania
-      code: 'pennsylvania'
+
+    psu: &id_psu
+      code: 'psu'
       name: 'Pennsylvania State University'
       idp_entity_id: 'urn:mace:incommon:psu.edu'
       display_order: 11
-    
+
     purdue: &id_purdue
       code: 'purdue'
       name: 'Purdue University'
       idp_entity_id: 'https://idp.purdue.edu/idp/shibboleth'
       display_order: 12
-    
+
     rutgers: &id_rutgers
       code: 'rutgers'
       name: 'Rutgers University'
       idp_entity_id: 'urn:mace:incommon:rutgers.edu'
       display_order: 13
-    
-    wisconsin: &id_wisconsin
-      code: 'wisconsin'
+
+    wisc: &id_wisc
+      code: 'wisc'
       name: 'University of Wisconsin-Madison'
       idp_entity_id: 'https://login.wisc.edu/idp/shibboleth'
       display_order: 14
@@ -134,64 +135,64 @@ production:
 # environment. See https://github.com/umd-lib/reciprocal-borrowing-vagrant
 development:
   organizations: &id_development_organization
-    chicago:
-      <<: *id_chicago
+    uchicago:
+      <<: *id_uchicago
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
 
-    illinois:
-      <<: *id_illinois
+    uiuc:
+      <<: *id_uiuc
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
 
-    indiana:
-      <<: *id_indiana
+    iu:
+      <<: *id_iu
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
 
-    iowa:
-      <<: *id_iowa
+    uiowa:
+      <<: *id_uiowa
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
-    
-    maryland:
-      <<: *id_maryland
+
+    umd:
+      <<: *id_umd
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
-    
-    university_of_michigan:
-      <<: *id_university_of_michigan
+
+    umich:
+      <<: *id_umich
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
-    
-    michigan_state:
-      <<: *id_michigan_state
+
+    msu:
+      <<: *id_msu
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
-    
-    minnesota:
-      <<: *id_minnesota
+
+    umn:
+      <<: *id_umn
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
-    
-    nebraska:
-      <<: *id_nebraska
+
+    unl:
+      <<: *id_unl
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
-    
+
     northwestern:
       <<: *id_northwestern
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
-    
-    ohio:
-      <<: *id_ohio
+
+    osu:
+      <<: *id_osu
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
-    
-    pennsylvania:
-      <<: *id_pennsylvania
+
+    psu:
+      <<: *id_psu
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
-    
+
     purdue:
       <<: *id_purdue
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
-    
+
     rutgers:
       <<: *id_rutgers
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
-    
-    wisconsin:
-      <<: *id_wisconsin
+
+    wisc:
+      <<: *id_wisc
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
 
 # Test Environment Configuration

--- a/test/controllers/shibboleth_login_controller_test.rb
+++ b/test/controllers/shibboleth_login_controller_test.rb
@@ -28,8 +28,51 @@ class ShibbolethLoginControllerTest < ActionController::TestCase
     end
   end
 
+  test 'authenticate should exist for each organization' do
+    organizations = Rails.configuration.shibboleth_config['organizations']
+    org_list = organizations.values.sort_by { |v| v['display_order'] }
+    org_list.each do |lending_org|
+      lending_org_code = lending_org['code']
+      get :authenticate, lending_org_code: lending_org_code
+      assert_response :success
+
+      # authenicate page should contain organization full name
+      assert_select '.lending-org-name', text: lending_org['name']
+    end
+  end
+
+  test 'authenticate should not contain link to lending org in org list' do
+    organizations = Rails.configuration.shibboleth_config['organizations']
+    org_list = organizations.values.sort_by { |v| v['display_order'] }
+    org_list.each do |lending_org|
+      lending_org_code = lending_org['code']
+      get :authenticate, lending_org_code: lending_org_code
+      assert_response :success
+
+      org_list.each do |initiate_org|
+        initiate_org_code = initiate_org['code']
+        list_id = "#{initiate_org_code}_entry"
+
+        # Make sure each organization has an initiate link, except for the
+        # lending organization
+        assert_select "ul#organization_list>li##{list_id}" do
+          if initiate_org_code == lending_org_code
+            assert_select 'a', { count: 0 }, "Link found for #{initiate_org_code}"
+          else
+            assert_select 'a', count: 1
+          end
+        end
+      end
+    end
+  end
+
+  test 'authenticate with invalid org code should show 404 error page' do
+    get :authenticate, lending_org_code: 'org_does_not_exist'
+    assert_redirected_to controller: 'errors', action: 'not_found'
+  end
+
   test 'should get initiator' do
-    get :initiator, org_code: 'maryland'
+    get :initiator, org_code: 'umd'
     assert_response :redirect
   end
 


### PR DESCRIPTION
Callback page now looks for an "eduPersonScopedAffiliation" property
from Shibboleth of the form "member@<auth_org_code>.edu". If the
property is found, the user is considered authorized. If not, the
user is considered not authorized.

Updated view to show whether the user was authorized. Removed
"Authentication Successful" banner, because the user will only
ever get to the page if the authentication is successful, and it
may have been confused with an authorization.

Added "lending_org_code" and "auth_org_code" to browser session cookies.

https://issues.umd.edu/browse/LIBITD-879