### PR TITLE
LIBITD-883. Update organization code for the University of Illinois

### DIFF
--- a/config/shibboleth_config.yml
+++ b/config/shibboleth_config.yml
@@ -41,8 +41,8 @@ production:
       idp_entity_id: 'urn:mace:incommon:uchicago.edu'
       display_order: 0
 
-    uiuc: &id_uiuc
-      code: 'uiuc'
+    illinois: &id_illinois
+      code: 'illinois'
       name: 'University of Illinois'
       idp_entity_id: 'urn:mace:incommon:uiuc.edu'
       display_order: 1
@@ -139,8 +139,8 @@ development:
       <<: *id_uchicago
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
 
-    uiuc:
-      <<: *id_uiuc
+    illinois:
+      <<: *id_illinois
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
 
     iu:


### PR DESCRIPTION
Updated University of Illinois organization code from "uiuc" to
"illinois" based on July 7, 2017 email to Ben Wallberg from BTAA
stakeholders.

https://issues.umd.edu/browse/LIBITD-883