### PR TITLE
LIBITD-888. Ignore case when matching affiliation strings.

### DIFF
--- a/app/controllers/shibboleth_login_controller.rb
+++ b/app/controllers/shibboleth_login_controller.rb
@@ -73,6 +73,6 @@ class ShibbolethLoginController < ApplicationController
     # affiliation: the eduPersonScopedAffiliation parameter from Shibboleth
     def user_authorized?(auth_org_code, affiliation)
       expected_affliation = "member@#{auth_org_code}.edu"
-      affiliation.split(';').include?(expected_affliation)
+      affiliation.split(';').any? { |a| a.downcase == expected_affliation }
     end
 end

--- a/test/controllers/shibboleth_login_controller_test.rb
+++ b/test/controllers/shibboleth_login_controller_test.rb
@@ -97,6 +97,17 @@ class ShibbolethLoginControllerTest < ActionController::TestCase
     assert_select '.user-authorized'
   end
 
+  test 'callback should show eligible for valid eduPersonScopedAffiliation, ignoring case' do
+    session[:lending_org_code] = 'umd'
+    session[:auth_org_code] = 'uiowa'
+    @request.env['eduPersonScopedAffiliation'] = 'Member@uiowa.edu'
+
+    get :callback
+
+    assert_response :success
+    assert_select '.user-authorized'
+  end
+
   test 'callback should show not eligible for invalid eduPersonScopedAffiliation' do
     # eduPersonScopedAffiliation is nil
     session[:lending_org_code] = 'umd'


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBITD-888