### PR TITLE
LIBITD-996. Change membership check from affiliation to entitlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The functionality of this application is extremely straightforward:
 
 3) After successfully authenticating, the browser is redirected back to this application, which indicates whether the patron is eligible to borrow.
 
-**Note:** The local development environment (when used in conjunction with the "reciprocal-borrowing-vagrant" as the Shibboleth SP and IdP) *cannot* show that a user is eligible to borrow because the IdP is not configured to pass the "eduPersonScopedAffiliation" back to the application. Conversely, when running on the dev, stage, or production servers, there is no known way to show that a user in ineligible for borrow because the UMD server always seems pass back the expected property.
+**Note:** The local development environment (when used in conjunction with the "reciprocal-borrowing-vagrant" as the Shibboleth SP and IdP) *cannot* show that a user is eligible to borrow because the IdP is not currently configured to pass the correct "eduPersonEntitlement" attribute back to the application. Conversely, when running on the dev, stage, or production servers, there is no known way to show that a user in ineligible for borrow because the UMD server always seems pass back the expected property.
 
 ## Application Configuration
 

--- a/app/controllers/shibboleth_login_controller.rb
+++ b/app/controllers/shibboleth_login_controller.rb
@@ -48,12 +48,11 @@ class ShibbolethLoginController < ApplicationController
 
     @name = @env['displayName'] || "#{@env['givenName']} #{@env['sn']}"
     @name = 'N/A' if @name.strip.empty?
-    @affiliation = @env['eduPersonScopedAffiliation'] || 'N/A'
     @principal_name = @env['eduPersonPrincipalName'] || 'N/A'
     @identifier = @env['eduPersonTargetedID'] || 'N/A'
     @entitlement = @env['eduPersonEntitlement'] || 'N/A'
 
-    @user_authorized = user_authorized?(@auth_org_code, @affiliation)
+    @user_authorized = user_authorized?(@entitlement)
 
     transaction_entry = "#{@identifier}," \
                         "lending_org_code=#{@lending_org_code || 'N/A'}," \
@@ -70,10 +69,9 @@ class ShibbolethLoginController < ApplicationController
 
     # Returns true is the user is authorized, false otherwise.
     #
-    # auth_org_code: The code of the organizaton performing the authorization
-    # affiliation: the eduPersonScopedAffiliation parameter from Shibboleth
-    def user_authorized?(auth_org_code, affiliation)
-      expected_affliation = "member@#{auth_org_code}.edu"
-      affiliation.split(';').any? { |a| a.downcase == expected_affliation }
+    # entitlement: the eduPersonEntitlement attribute from Shibboleth
+    def user_authorized?(entitlement)
+      expected_entitlement = 'https://borrow.btaa.org/reciprocalborrower'
+      entitlement.split(';').any? { |e| e.downcase == expected_entitlement }
     end
 end

--- a/app/views/shibboleth_login/authenticate.html.erb
+++ b/app/views/shibboleth_login/authenticate.html.erb
@@ -10,7 +10,7 @@
 
           <p>To authenticate, please click on your home institution below
           and log-in using your institution user ID and password. A
-          successful result will return your name, affiliation, and
+          successful result will return your name, entitlement, and
           personal identifier number.</p>
         </div>
 

--- a/app/views/shibboleth_login/callback.html.erb
+++ b/app/views/shibboleth_login/callback.html.erb
@@ -10,10 +10,6 @@
             <td><%= @name %></td>
           </tr>
           <tr>
-            <th>Affiliation:</th>
-            <td><%= @affiliation %></td>
-          </tr>
-          <tr>
             <th>Entitlement:</th>
             <td><%= @entitlement %></td>
           </tr>
@@ -34,7 +30,7 @@
             </p>
           <% else %>
             <p class="user-not-authorized">
-              User is <strong>NOT</strong> eligible for borrowing – not recognized as member@<%= @auth_org_code %>.edu
+              User is <strong>NOT</strong> eligible for borrowing due to missing "https://borrow.btaa.org/reciprocalborrower" in the eduPersonEntitlement.
             <p>
           <% end %>
           <p>

--- a/test/controllers/shibboleth_login_controller_test.rb
+++ b/test/controllers/shibboleth_login_controller_test.rb
@@ -86,10 +86,10 @@ class ShibbolethLoginControllerTest < ActionController::TestCase # rubocop:disab
     assert_response :success
   end
 
-  test 'callback should show eligible for valid eduPersonScopedAffiliation' do
+  test 'callback should show eligible for valid eduPersonEntitlement' do
     session[:lending_org_code] = 'umd'
     session[:auth_org_code] = 'uiowa'
-    @request.env['eduPersonScopedAffiliation'] = 'member@uiowa.edu'
+    @request.env['eduPersonEntitlement'] = 'https://borrow.btaa.org/reciprocalborrower'
 
     get :callback
 
@@ -97,10 +97,10 @@ class ShibbolethLoginControllerTest < ActionController::TestCase # rubocop:disab
     assert_select '.user-authorized'
   end
 
-  test 'callback should show eligible for valid eduPersonScopedAffiliation, ignoring case' do
+  test 'callback should show eligible for valid eduPersonEntitlement, ignoring case' do
     session[:lending_org_code] = 'umd'
     session[:auth_org_code] = 'uiowa'
-    @request.env['eduPersonScopedAffiliation'] = 'Member@uiowa.edu'
+    @request.env['eduPersonEntitlement'] = 'HTTPS://borrow.BTAA.org/reciprocalBorrower'
 
     get :callback
 
@@ -108,8 +108,8 @@ class ShibbolethLoginControllerTest < ActionController::TestCase # rubocop:disab
     assert_select '.user-authorized'
   end
 
-  test 'callback should show not eligible for invalid eduPersonScopedAffiliation' do
-    # eduPersonScopedAffiliation is nil
+  test 'callback should show not eligible for invalid eduPersonEntitlement' do
+    # eduPersonEntitlement is nil
     session[:lending_org_code] = 'umd'
     session[:auth_org_code] = 'uiowa'
 
@@ -118,20 +118,20 @@ class ShibbolethLoginControllerTest < ActionController::TestCase # rubocop:disab
     assert_response :success
     assert_select '.user-not-authorized'
 
-    # eduPersonScopedAffiliation is N/A
+    # eduPersonEntitlement is N/A
     session[:lending_org_code] = 'umd'
     session[:auth_org_code] = 'uiowa'
-    @request.env['eduPersonScopedAffiliation'] = 'N/A'
+    @request.env['eduPersonEntitlement'] = 'N/A'
 
     get :callback
 
     assert_response :success
     assert_select '.user-not-authorized'
 
-    # auth_org code does not match eduPersonScopedAffiliation
+    # eduPersonEntitlement is some other string
     session[:lending_org_code] = 'umd'
     session[:auth_org_code] = 'uiowa'
-    @request.env['eduPersonScopedAffiliation'] = 'member@rutgers.edu'
+    @request.env['eduPersonEntitlement'] = 'not_a_reciprocal_borrower'
 
     get :callback
 


### PR DESCRIPTION
Changed borrow eligibility check from using the
"eduPersonScopedAffiliation" attribute to the "eduPersonEntitlement"
attribute.

Removed usage of "eduPersonScopedAffiliation" attribute from code, as
it is no longer needed.

Removed "Affiliation" field from callback view.

Updated test cases.

https://issues.umd.edu/browse/LIBITD-996