### PR TITLE
LIBITD-2230. Changed name to "Indiana University Bloomington"

### DIFF
--- a/config/shibboleth_config.yml
+++ b/config/shibboleth_config.yml
@@ -49,7 +49,7 @@ production:
 
     iu: &id_iu
       code: 'iu'
-      name: 'Indiana University'
+      name: 'Indiana University Bloomington'
       idp_entity_id: 'urn:mace:incommon:iu.edu'
       display_order: 2
 


### PR DESCRIPTION
At the request of Jon William Butcher Dunn (jwd@iu.edu), changed the name of "Indiana University" on the lending institution and the home institution pages to “Indiana University Bloomington”.

https://issues.umd.edu/browse/LIBITD-2230