### PR TITLE
LIBITD-2422. Added "development_docker" Rails environment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.4)
     minitest (5.18.1)
     minitest-ci (3.0.3)
       minitest (~> 5.0, >= 5.0.6)
@@ -126,6 +127,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.3)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.3-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.15.3-arm64-darwin)
@@ -250,6 +254,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   bootstrap-sass (= 3.3.6)

--- a/README.md
+++ b/README.md
@@ -169,6 +169,6 @@ See the [LICENSE](LICENSE.md) file for license rights and limitations
 
 ---
 [btaa]: https://www.btaa.org/
-[btaa_reciprocal_borrowing]: https://www.btaa.org/projects/library/reciprocal-borrowing/introduction
+[btaa_reciprocal_borrowing]: https://www.btaa.org/projects/library/reciprocal-borrowing/
 [dev-env]: https://github.com/umd-lib/reciprocal-borrowing-dev-env
 [incommon]: https://www.incommon.org/

--- a/README.md
+++ b/README.md
@@ -27,17 +27,31 @@ Reciprocal Borrowing is different from other UMD/SSDR Rails applications:
 
 ## Quick Start
 
-This application must be added to a server acting as a Shibboleth Service
-Provider (SP). In order to be used in a production environment, the SP must be
-registered with [InCommon](https://www.incommon.org/)).
-
-For local development, this application can be used in conjunction with the
-Vagrant-based Shibboleth Identity Provider (IdP) and SP provided in the
-[umd-lib/reciprocal-borrowing-vagrant](https://github.com/umd-lib/reciprocal-borrowing-vagrant)
+For local development, this application can be used in conjunction with a
+Docker-based Shibboleth Identity Provider (IdP) and SP provided in the
+[umd-lib/reciprocal-borrowing-dev-env](https://github.com/umd-lib/reciprocal-borrowing-dev-env)
 GitHub repository. Refer to the README.md file in that repository for setup
 instructions.
 
+### "development_docker" Environment
+
+An additional "development_docker" environment has been added to the
+Rails standard "development", "test", and "production" environments, to support
+running in the "umd-lib/reciprocal-borrowing-dev-env" Docker stack.
+
+This environment contains:
+
+* changes to use the "borrow-local" hostname
+* changes to the "Univerisity of Maryland" Shibboleth link to use the Shibboleth
+  IdP in the Docker stack
+* modifications to support running on M-series (Apple Silicon) laptops
+* Values for the environment variables in the ".env" file
+
 ## Application Functionality
+
+This application must be added to a server acting as a Shibboleth Service
+Provider (SP). In order to be used in a production environment, the SP must be
+registered with [InCommon](https://www.incommon.org/)).
 
 The functionality of this application is extremely straightforward:
 
@@ -60,11 +74,7 @@ The functionality of this application is extremely straightforward:
 4) After successfully authenticating, the browser is redirected back to this
    application, which indicates whether the patron is eligible to borrow.
 
-**Note:** The local development environment (when used in conjunction with the
-"reciprocal-borrowing-vagrant" as the Shibboleth SP and IdP) *cannot* show that
-a user is eligible to borrow because the IdP is not currently configured to pass
-the correct "eduPersonEntitlement" attribute back to the application.
-Conversely, when running on the dev, stage, or production servers, there is no
+**Note:** When running on the dev, stage, or production servers, there is no
 known way to show that a user in ineligible for borrow because the UMD server
 always seems pass back the expected property.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # reciprocal-borrowing
 
 This Rails application is designed to work with Shibboleth and the
-[InCommon](https://www.incommon.org/) identity management federation to verify
-patron eligibility for
-[reciprocal borrowing](https://www.btaa.org/projects/library/reciprocal-borrowing/introduction)
-between members of the [Big Ten Academic Alliance](https://www.btaa.org/).
+[InCommon][incommon] identity management federation to verify patron eligibility
+for [reciprocal borrowing][btaa_reciprocal_borrowing] between members of the
+[Big Ten Academic Alliance][btaa].
 
 Reciprocal Borrowing is different from other UMD/SSDR Rails applications:
 
@@ -28,9 +27,9 @@ Reciprocal Borrowing is different from other UMD/SSDR Rails applications:
 ## Quick Start
 
 For local development, this application can be used in conjunction with a
-Docker-based Shibboleth Identity Provider (IdP) and SP provided in the
-[umd-lib/reciprocal-borrowing-dev-env](https://github.com/umd-lib/reciprocal-borrowing-dev-env)
-GitHub repository. Refer to the README.md file in that repository for setup
+Docker-based Shibboleth Identity Provider (IdP) and Shibboleth Service Provider
+(SP) provided in the [umd-lib/reciprocal-borrowing-dev-env][dev-env] GitHub
+repository. Refer to the README.md file in that repository for setup
 instructions.
 
 ### "development_docker" Environment
@@ -42,8 +41,8 @@ running in the "umd-lib/reciprocal-borrowing-dev-env" Docker stack.
 This environment contains:
 
 * changes to use the "borrow-local" hostname
-* changes to the "Univerisity of Maryland" Shibboleth link to use the Shibboleth
-  IdP in the Docker stack
+* changes to the "shibboleth_config.yml" file so that all organizations use the
+  Shibboleth IdP in the Docker stack
 * modifications to support running on M-series (Apple Silicon) laptops
 * Values for the environment variables in the ".env" file
 
@@ -51,7 +50,7 @@ This environment contains:
 
 This application must be added to a server acting as a Shibboleth Service
 Provider (SP). In order to be used in a production environment, the SP must be
-registered with [InCommon](https://www.incommon.org/)).
+registered with [InCommon][incommon]).
 
 The functionality of this application is extremely straightforward:
 
@@ -83,7 +82,7 @@ always seems pass back the expected property.
 The "transactions.log" file contains the results of *completed* authentications,
 in which the user was successfully authenticated.
 
-Each line in the "tranactions.log" file has the following form:
+Each line in the "transactions.log" file has the following form:
 
 ```text
 [<TIMESTAMP>] <IDENTIFIER>,lending_org_code=<LENDING_ORG>,auth_org_code=<AUTH_ORG>,authorized=[true|false]
@@ -101,21 +100,22 @@ where:
 * \<AUTH_ORG>: The code (from "config/shibboleth_config.yml") of the
   organization used to authenticate the user.
 
-If "authorized" it "true", the user is authorized to borrow, if "false" the
+If "authorized" is "true", the user is authorized to borrow, if "false" the
 user is not.
 
 ## Application Configuration
 
 The config/shibboleth_config.yml file contains the configuration information for
-he organizations participating in reciprocal borrowing, and has been
+the organizations participating in reciprocal borrowing, and has been
 pre-populated with Big Ten Academic Alliance members. The file contains
-different sections for the "production", "development", and "test" environments.
+different sections for the "production", "development", "development_docker",
+and "test" environments.
 
 The application should work "out of the box" when used in conjunction with the
-[umd-lib/reciprocal-borrowing-vagrant](https://github.com/umd-lib/reciprocal-borrowing-vagrant)
-GitHub repository, in a "development" Rails environment. The "development"
-section of the shibboleth_config.yml has been pre-configured so that
-"idp_entity_id" for all organizations points to the Vagrant IdP.
+[umd-lib/reciprocal-borrowing-dev-env][dev-env] GitHub repository, in a
+"development_docker" Rails environment. The "development_docker" section of the
+shibboleth_config.yml has been pre-configured so that "idp_entity_id" for all
+organizations points to the Docker IdP.
 
 For a "production" environment, the shibboleth_config.yml file has been
 pre-populated "idp_entity_id" values derived from the InCommon metadata for
@@ -142,7 +142,8 @@ By default, in the local development environment (determined by
 `Rails.env.development?`returning `true`), a "Local Environment" banner will be
 displayed.
 
-On non-production servers, the environment banner can be configured using the following environment variables:
+On non-production servers, the environment banner can be configured using the
+following environment variables:
 
 * ENVIRONMENT_BANNER - the text to display in the banner
 * ENVIRONMENT_BANNER_FOREGROUND - the foreground color for the banner, as a CSS color
@@ -165,3 +166,9 @@ ENVIRONMENT_BANNER=Example Banner Environment
 
 See the [LICENSE](LICENSE.md) file for license rights and limitations
 (Apache 2.0).
+
+---
+[btaa]: https://www.btaa.org/
+[btaa_reciprocal_borrowing]: https://www.btaa.org/projects/library/reciprocal-borrowing/introduction
+[dev-env]: https://github.com/umd-lib/reciprocal-borrowing-dev-env
+[incommon]: https://www.incommon.org/

--- a/app/views/shibboleth_login/callback.html.erb
+++ b/app/views/shibboleth_login/callback.html.erb
@@ -38,7 +38,7 @@
           <p>
         </section>
 
-        <% if Rails.env.development? %>
+        <% if Rails.env.development? || Rails.env.development_docker? %>
           <div class="panel panel-warning">
             <div class="panel-heading">
 

--- a/config/environments/development_docker.rb
+++ b/config/environments/development_docker.rb
@@ -1,0 +1,22 @@
+# Based on development defaults
+require Rails.root.join("config/environments/development")
+
+Rails.application.configure do
+  # Add "borrow-local" (the hostname used by the Docker container) to the list
+  # of allowed hosts.
+  config.hosts << "borrow-local"
+
+  # The default Rails "config.file_watcher" setting of
+  # "ActiveSupport::EventedFileUpdateChecker" does not appear to work when
+  # running in a Docker image on M-series (Apple Silicon) laptops, so modifying
+  # to use an alternate file watcher
+  config.file_watcher = ActiveSupport::FileUpdateChecker
+
+  # .env Environment Variables
+  ENV['SECRET_KEY_BASE'] = '449dd5287e47b8bbe4c85bd38424a10a105b1f84ff44ade491c48a791c48ad09dc64c548e7328a04b3634dc4d385bd7e3a7ad3e77d6c65a433f2b27337f3327f'
+
+  ENV['ENVIRONMENT_BANNER_ENABLED'] = 'true'
+  ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#008080'
+  ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ffffff'
+  ENV['ENVIRONMENT_BANNER'] = 'Docker Development Environment'
+end

--- a/config/shibboleth_config.yml
+++ b/config/shibboleth_config.yml
@@ -199,3 +199,11 @@ development:
 test:
   organizations:
     <<: *id_development_organization
+
+# development_docker Environment Configuration
+development_docker:
+  organizations:
+    <<: *id_development_organization
+    umd:
+      <<: *id_umd
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'

--- a/config/shibboleth_config.yml
+++ b/config/shibboleth_config.yml
@@ -195,15 +195,71 @@ development:
       <<: *id_wisc
       idp_entity_id: 'https://192.168.33.10/idp/shibboleth'
 
-# Test Environment Configuration
-test:
-  organizations:
-    <<: *id_development_organization
-
 # development_docker Environment Configuration
 development_docker:
   organizations:
     <<: *id_development_organization
+    uchicago:
+      <<: *id_uchicago
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    illinois:
+      <<: *id_illinois
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    iu:
+      <<: *id_iu
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    uiowa:
+      <<: *id_uiowa
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
     umd:
       <<: *id_umd
       idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    umich:
+      <<: *id_umich
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    msu:
+      <<: *id_msu
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    umn:
+      <<: *id_umn
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    unl:
+      <<: *id_unl
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    northwestern:
+      <<: *id_northwestern
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    osu:
+      <<: *id_osu
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    psu:
+      <<: *id_psu
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    purdue:
+      <<: *id_purdue
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    rutgers:
+      <<: *id_rutgers
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+    wisc:
+      <<: *id_wisc
+      idp_entity_id: 'https://shib-idp/idp/shibboleth'
+
+# Test Environment Configuration
+test:
+  organizations:
+    <<: *id_development_organization


### PR DESCRIPTION
Added a "development_docker" Rails environment (similar to the
exisiting stock Rails "development", "production", and "test"
environments) to enable a working configuration for use with the
"umd-lib/reciprocal-borrowing-dev-env" Docker Compose stack.

Modified the "callback" page to show debugging information when
either the "development" or "development_docker" environments
were being used.

Added a "development_docker" section to the "config/shibboleth.yml"
file to point all organizations to the Shibboleth IdP in the Docker Compose
stack.

Updated the README.md

https://umd-dit.atlassian.net/browse/LIBITD-2422