### PR TITLE
LIBITD-2625. Updated "Dockerfile" for Kubernetes for Rails 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ GitHub for information about setting up a MacBook to use the Kubernetes
 5) Create the "docker.lib.umd.edu/reciprocal-borrowing" Docker image:
 
     ```bash
-    $ docker buildx build --no-cache --platform linux/amd64 --push --no-cache \
+    $ docker buildx build --no-cache --platform linux/amd64 --push \
         --builder=kube  -f Dockerfile -t docker.lib.umd.edu/reciprocal-borrowing:$APP_TAG .
     ```
 


### PR DESCRIPTION
Removed some commented out/obsolete directives and added directives to install Node and Yarn, which are needed by the Rails 8.1 import pipeline.

Removed a repeated "--no-cache" argument in the Docker build command in the "README.md" file.

https://umd-dit.atlassian.net/browse/LIBITD-2625