### PR TITLE
LIBITD-2697. Replace DSS reference with DST in "Hosting and Technology"

### DIFF
--- a/app/views/shibboleth_login/hosting.html.erb
+++ b/app/views/shibboleth_login/hosting.html.erb
@@ -6,16 +6,16 @@
       <div class="row">
         <h2>Hosting and Technology</h2>
 
-        <p>The Reciprocal Borrowing application is built with the <a href="http://rubyonrails.org/">Ruby on Rails</a>
+        <p>The Reciprocal Borrowing application is built with the <a href="https://rubyonrails.org/">Ruby on Rails</a>
         web framework and <a href="https://shibboleth.net/">Shibboleth federated identity management</a> technologies.
         The source code is available at the GitHub <a
           href="https://github.com/umd-lib/reciprocal-borrowing">umd-lib/reciprocal-borrowing</a> repository. The
-        application is built and hosted by the <a href="http://www.lib.umd.edu">University of Maryland Libraries</a> <a
-          href="http://www.lib.umd.edu/dss">Digital Systems and Stewardship</a> division.</p>
+        application is built and hosted by the <a href="https://www.lib.umd.edu/">University of Maryland Libraries</a>
+        <a href="https://www.lib.umd.edu/about/org/dst">Digital Services and Technologies</a> division.</p>
 
         <ul>
-          <li><a href="http://www.lib.umd.edu/about/privacy-info">Privacy Information</a></li>
-          <li><a href="http://it.umd.edu/aup">Acceptable Use of IT Resources</a></li>
+          <li><a href="https://www.lib.umd.edu/about/policies/privacy">Privacy Information</a></li>
+          <li><a href="https://it.umd.edu/aup">Acceptable Use of IT Resources</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
* Updated app/views/shibboleth_login/hosting.html.erb:
  * Replaced “Digital Systems and Stewardship” reference with “Digital Services and Technologies”, and updated the hyperlink to https://www.lib.umd.edu/about/org/dst
  * Updated other “http://” hyperlinks on the page to “https://”

https://umd-dit.atlassian.net/browse/LIBITD-2697